### PR TITLE
Add calendar page

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <title>OSCA Hack Club Calendar</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <dyn-header></dyn-header>
+    <iframe src="https://outlook.office365.com/owa/calendar/f0005c92ad71415c9027de0d6410073a@ormistonsandwell.org.uk/eac05b96073f4324bc2a9b382f5f9a9b8437742454327547749/calendar.html" width="100%" height="600px"></iframe>
+    <dyn-footer></dyn-footer>
+    <script src="/headerfooter.js"></script>
+  </body>
+</html>

--- a/headerfooter.js
+++ b/headerfooter.js
@@ -7,6 +7,7 @@ class DynHeader extends HTMLElement {
           <nav>
               <ul>
                   <li><a href="/index.html">Home</a></li>
+                  <li><a href="/calendar.html">Calendar</a></li>
               </ul>
           </nav>
           </header>

--- a/styles.css
+++ b/styles.css
@@ -173,3 +173,9 @@ p {
   padding: 10px;
   margin: 10px;
 }
+
+iframe {
+  width: 100%;
+  height: 600px;
+  border: none;
+}


### PR DESCRIPTION
Add a calendar page to display upcoming club meetings and their topics.

* Create a new `calendar.html` file with a `dyn-header` custom element, an iframe for the calendar, and a `dyn-footer` custom element.
* Update `headerfooter.js` to include a navigation link to the new calendar page.
* Add CSS styles in `styles.css` for the iframe to ensure it fits well within the layout of the website.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OSCA-Hack-Club/OSCA-Hack-Club.github.io?shareId=33be10da-0c3e-4599-a026-6b8fcb110fc1).