### PR TITLE
Replace calendar embed and improve responsiveness

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -4,11 +4,39 @@
     <title>OSCA Hack Club Calendar</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/styles.css" />
+    <style>
+      .spinner {
+        border: 16px solid #f3f3f3;
+        border-top: 16px solid #a633d6;
+        border-radius: 50%;
+        width: 120px;
+        height: 120px;
+        animation: spin 2s linear infinite;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
+
+      @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+      }
+    </style>
   </head>
   <body>
     <dyn-header></dyn-header>
-    <iframe src="https://outlook.office365.com/owa/calendar/f0005c92ad71415c9027de0d6410073a@ormistonsandwell.org.uk/eac05b96073f4324bc2a9b382f5f9a9b8437742454327547749/calendar.html" width="100%" style="height: 80vh;"></iframe>
+    <div id="spinner" class="spinner"></div>
+    <iframe src="https://teamup.com/ksdboqutzm352tf39d?showProfileAndInfo=0&showSidepanel=1&disableSidepanel=1&showViewHeader=1&showAgendaDetails=1&showDateControls=1" style="width: 100%; height: 80vh; border: 1px solid #cccccc; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);" loading="lazy" frameborder="0"></iframe>
     <dyn-footer></dyn-footer>
     <script src="/headerfooter.js"></script>
+    <script>
+      const iframe = document.querySelector('iframe');
+      const spinner = document.getElementById('spinner');
+
+      iframe.onload = function() {
+        spinner.style.display = 'none';
+      };
+    </script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -183,8 +183,27 @@ p {
 
 iframe {
   width: 100%;
-  height: 37.5rem;
-  border: none;
+  height: 80vh;
+  border: 1px solid #cccccc;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.spinner {
+  border: 16px solid #f3f3f3;
+  border-top: 16px solid #a633d6;
+  border-radius: 50%;
+  width: 120px;
+  height: 120px;
+  animation: spin 2s linear infinite;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 
 @media (max-width: 768px) {
@@ -204,6 +223,9 @@ iframe {
   li a {
     font-size: 0.875rem;
   }
+  iframe {
+    height: 60vh;
+  }
 }
 
 @media (max-width: 480px) {
@@ -222,5 +244,8 @@ iframe {
   }
   li a {
     font-size: 0.75rem;
+  }
+  iframe {
+    height: 50vh;
   }
 }


### PR DESCRIPTION
Replace the current calendar embed with the new Teamup calendar embed and make it mobile responsive.

* **calendar.html**
  - Replace the current Outlook calendar iframe with the new Teamup calendar iframe.
  - Add a loading indicator using JavaScript to show a spinner until the iframe content is fully loaded.
  - Add inline styles for the spinner and iframe, including a border and shadow for the iframe.

* **styles.css**
  - Add styles for the spinner to match the overall design of the site.
  - Add media queries for the calendar embed to ensure responsiveness.
  - Set the iframe height to `80vh` for responsiveness.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OSCA-Hack-Club/OSCA-Hack-Club.github.io?shareId=2ce23af0-bc2f-423b-9f95-fa097678e984).